### PR TITLE
Handle cases where a model does not repeat the function signature

### DIFF
--- a/Evaluation/HumanEval/utils/utils.py
+++ b/Evaluation/HumanEval/utils/utils.py
@@ -70,9 +70,10 @@ def extract_generation_code(example: str, lang_code: str, verbose: bool=False):
             code_block = code_block[:main_start]
         
         func_name, func_prefix = get_function_name(question, lang)
-
+        found_signature = False
         try:
             start = code_block.lower().index(func_name.lower())
+            found_signature = True
             indent = 0
             while start - indent >= 0 and code_block[start - indent-1] == ' ':
                 indent += 1
@@ -93,7 +94,10 @@ def extract_generation_code(example: str, lang_code: str, verbose: bool=False):
         if lang_code.lower() in ['php', 'ts', 'js']:
             body += '\n' + ' '*indent + '}'
     
-        generation = func_prefix + '\n' + body + '\n'
+        if not found_signature:
+            generation = question + '\n' + body + '\n'
+        else:
+            generation = func_prefix + '\n' + body + '\n'
         example['generation'] = generation
 
     except Exception as ex:


### PR DESCRIPTION
This PR attempts to handle cases where a model does not repeat the function signature.

Note that the variable `start` denotes the position of the queried function signature, and it will be set to `0` the function signature is not found in a model's response.

Suppose that the query prompt is
```cpp
// query prefix here
void strlen(string s){
```

If a model returns
```cpp
    return s.length();
}
```

The original processing code yields
```cpp
// query prefix here
    return s.length();
```
which fails to compile.

A possible fix (as proposed by this PR) is not to skip the function signature when it's not found in a model's response.
That is, instead of returning `func_prefix + '\n' + body + '\n'`, the function returns `question + '\n' + body` when the signature is not found.

