### PR TITLE
fixed finetune requirements.txt

### DIFF
--- a/finetune/install.sh
+++ b/finetune/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+pip install -r requirements.txt
+DS_BUILD_CPU_ADAM=1 pip install deepspeed==0.14.5
+

--- a/finetune/requirements.txt
+++ b/finetune/requirements.txt
@@ -2,9 +2,9 @@ torch==2.0.1
 tokenizers==0.14.0
 transformers==4.35.0
 accelerate==0.24.1
+numpy==1.26.4
 attrdict
 tqdm
 
-deepspeed==0.12.2
 datasets
 tensorboardX


### PR DESCRIPTION
Fixes #642 

# Fix
1. `ImportError: cannot import name 'BUFSIZE' from 'numpy' (/root/finetune/lib/python3.10/site-packages/numpy/__init__.py)`
Solution: `numpy<2.0.0` is required.
2. `AttributeError: 'DeepSpeedCPUAdam' object has no attribute 'ds_opt_adam'`
Solution: _deepspeed_ installation with an environmental variable `DS_BUILD_CPU_ADAM` set to 1 is required.
3. But `pydantic_core._pydantic_core.ValidationError: 1 validation error for DeepSpeedZeroConfig` will be thrown if we install the specified in the source _requirements.txt_ version of deepspeed (ver. 0.12.2) with the aforementioned env var set to 1.
Solution: `DS_BUILD_CPU_ADAM=1 pip install deepspeed==0.14.5`

Since we can't specify environmental variables in _requirements.txt_ I added a shell script that installs everything in the fixed _requirements.txt_ and the correct deepspeed version with the required env var set to 1 to fix the issue №2.

# Install
To install fixed dependancies:
```
cd finetune/
./install.sh
```
